### PR TITLE
refactor: split webhook in two classes by method

### DIFF
--- a/lib/http/webhook.rb
+++ b/lib/http/webhook.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require 'sorbet-runtime'
+require_relative 'webhook/get'
+require_relative 'webhook/post'
 
 module Http
   # :nodoc:
@@ -15,9 +17,20 @@ module Http
       @request = request
     end
 
-    sig { returns(String) }
+    sig { returns(T::Array[T.any(Integer, Hash, String)]) }
     def response
-      "Received request url: #{request.url}\n"
+      responder.new(request).response
+    end
+
+    private
+
+    def responder
+      case request.request_method
+      when 'GET'
+        Webhook::Get
+      when 'POST'
+        Webhook::Post
+      end
     end
   end
 end

--- a/lib/http/webhook/get.rb
+++ b/lib/http/webhook/get.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+require 'sorbet-runtime'
+
+module Http
+  class Webhook
+    # :nodoc:
+    class Get
+      extend T::Sig
+
+      attr_reader :request
+
+      sig { params(request: Rack::Request).void }
+      def initialize(request)
+        @request = request
+      end
+
+      sig { returns(T::Array[T.any(Integer, Hash, String)]) }
+      def response
+        [200, {}, 'get']
+      end
+    end
+  end
+end

--- a/lib/http/webhook/get.rb
+++ b/lib/http/webhook/get.rb
@@ -9,6 +9,8 @@ module Http
     class Get
       extend T::Sig
 
+      VERIFY_TOKEN = ENV.fetch('STRAVA_WEBHOOK_VERIFY_TOKEN', 'abc123')
+
       attr_reader :request
 
       sig { params(request: Rack::Request).void }
@@ -16,9 +18,25 @@ module Http
         @request = request
       end
 
-      sig { returns(T::Array[T.any(Integer, Hash, String)]) }
+      sig { returns(T::Array[T.any(Integer, T::Hash[String, String], T::Array[String])]) }
       def response
-        [200, {}, 'get']
+        return make_response(401, error: 'wrong verify token') if request.params['hub.verify_token'] != VERIFY_TOKEN
+        return make_response(422, error: 'empty challenge') if request.params['hub.challenge'].to_s.empty?
+
+        make_response(200, { 'hub.challenge': request.params['hub.challenge'] })
+      end
+
+      private
+
+      sig do
+        params(status: Integer, body: Hash).returns(T::Array[T.any(Integer, T::Hash[String, String], T::Array[String])])
+      end
+      def make_response(status, body)
+        [
+          status,
+          { 'Content-Type' => 'application/json' },
+          [body.to_json]
+        ]
       end
     end
   end

--- a/lib/http/webhook/post.rb
+++ b/lib/http/webhook/post.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+require 'sorbet-runtime'
+
+module Http
+  class Webhook
+    # :nodoc:
+    class Post
+      extend T::Sig
+
+      attr_reader :request
+
+      sig { params(request: Rack::Request).void }
+      def initialize(request)
+        @request = request
+      end
+
+      sig { returns(T::Array[T.any(Integer, Hash, String)]) }
+      def response
+        [200, {}, 'post']
+      end
+    end
+  end
+end

--- a/spec/http/webhook/get_spec.rb
+++ b/spec/http/webhook/get_spec.rb
@@ -1,0 +1,18 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rspec'
+require 'functions_framework/testing'
+
+require './lib/http/webhook/get'
+
+describe Http::Webhook::Get do
+  include FunctionsFramework::Testing
+
+  subject(:responder) { described_class.new(request) }
+
+  let(:request) { make_get_request 'https://example.com/webhook' }
+
+  it { expect(responder.response.first).to eq 200 }
+  it { expect(responder.response.last).to eq 'get' }
+end

--- a/spec/http/webhook/get_spec.rb
+++ b/spec/http/webhook/get_spec.rb
@@ -9,10 +9,28 @@ require './lib/http/webhook/get'
 describe Http::Webhook::Get do
   include FunctionsFramework::Testing
 
-  subject(:responder) { described_class.new(request) }
+  subject(:response) { described_class.new(request).response }
 
-  let(:request) { make_get_request 'https://example.com/webhook' }
+  let(:url) { 'https://example.com/webhook?hub.verify_token=abc123&hub.challenge=15f7d1a91c1f&hub.mode=subscribe' }
+  let(:request) do
+    make_get_request url
+  end
 
-  it { expect(responder.response.first).to eq 200 }
-  it { expect(responder.response.last).to eq 'get' }
+  it { expect(response[0]).to eq 200 }
+  it { expect(response[1]).to include 'Content-Type' => 'application/json' }
+  it { expect(response[2]).to include({ 'hub.challenge': '15f7d1a91c1f' }.to_json) }
+
+  context 'when verify token is invalid' do
+    let(:url) { 'https://example.com/webhook?hub.verify_token=invalid&hub.challenge=15f7d1a91c1f&hub.mode=subscribe' }
+
+    it { expect(response[0]).to eq 401 }
+    it { expect(response[2]).to include({ error: 'wrong verify token' }.to_json) }
+  end
+
+  context 'when challenge is empty' do
+    let(:url) { 'https://example.com/webhook?hub.verify_token=abc123&hub.challenge=&hub.mode=subscribe' }
+
+    it { expect(response[0]).to eq 422 }
+    it { expect(response[2]).to include({ error: 'empty challenge' }.to_json) }
+  end
 end

--- a/spec/http/webhook/post_spec.rb
+++ b/spec/http/webhook/post_spec.rb
@@ -1,0 +1,20 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rspec'
+require 'functions_framework/testing'
+
+require './lib/http/webhook/post'
+
+describe Http::Webhook::Post do
+  include FunctionsFramework::Testing
+
+  subject(:responder) { described_class.new(request) }
+
+  let(:request) do
+    make_post_request 'https://example.com/webhook', '{"name":"Ruby"}', ['Content-Type: application/json']
+  end
+
+  it { expect(responder.response.first).to eq 200 }
+  it { expect(responder.response.last).to eq 'post' }
+end

--- a/spec/http/webhook_spec.rb
+++ b/spec/http/webhook_spec.rb
@@ -9,7 +9,7 @@ describe 'Http::Webhook' do
 
   it 'GET /' do
     load_temporary 'app.rb' do
-      request = make_get_request 'https://example.com/webhook'
+      request = make_get_request 'https://example.com/webhook?hub.verify_token=abc123&hub.challenge=15f7d1a91c1f40f8a748fd134752feb3&hub.mode=subscribe'
       response = call_http 'webhook', request
 
       expect(response).to be_successful

--- a/spec/http/webhook_spec.rb
+++ b/spec/http/webhook_spec.rb
@@ -7,7 +7,7 @@ require 'functions_framework/testing'
 describe 'Http::Webhook' do
   include FunctionsFramework::Testing
 
-  it 'GET' do
+  it 'GET /' do
     load_temporary 'app.rb' do
       request = make_get_request 'https://example.com/webhook'
       response = call_http 'webhook', request
@@ -16,7 +16,7 @@ describe 'Http::Webhook' do
     end
   end
 
-  it 'POST' do
+  it 'POST /' do
     load_temporary 'app.rb' do
       request = make_post_request 'https://example.com/webhook', '{"name":"Ruby"}', ['Content-Type: application/json']
       response = call_http 'webhook', request


### PR DESCRIPTION
Based on [Strava docs](https://developers.strava.com/docs/webhooks/).

- [x] adds support to `GET /` to validate endpoint
- [ ] adds support to `POST /` to record received data